### PR TITLE
add an explicit dependency on generated files in CMake

### DIFF
--- a/libuvc_camera/CMakeLists.txt
+++ b/libuvc_camera/CMakeLists.txt
@@ -28,10 +28,12 @@ include_directories(${Boost_INCLUDE_DIRS})
 
 add_executable(camera_node src/main.cpp src/camera_driver.cpp)
 target_link_libraries(camera_node ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${libuvc_LIBRARIES})
+add_dependencies(camera_node ${PROJECT_NAME}_gencfg)
 
 add_library(libuvc_camera_nodelet src/nodelet.cpp src/camera_driver.cpp)
 add_dependencies(libuvc_camera_nodelet ${libuvc_camera_EXPORTED_TARGETS})
 target_link_libraries(libuvc_camera_nodelet ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${libuvc_LIBRARIES})
+add_dependencies(camera_nodelet ${PROJECT_NAME}_gencfg)
 
 install(TARGETS camera_node libuvc_camera_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
This will make sure that the generated headers are build before they are compiled which is currently a race condition. 

This fixes the error shown here: http://jenkins.ros.org/view/HbinP32/job/ros-hydro-libuvc-camera_binarydeb_precise_i386/25/console

```
[ 20%] Building CXX object CMakeFiles/camera_node.dir/src/main.cpp.o
/usr/lib/ccache/c++   -DROS_PACKAGE_NAME=\"libuvc_camera\" -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security  -I/tmp/buildd/ros-hydro-libuvc-camera-0.0.2-2precise-20130923-0631/obj-i686-linux-gnu/devel/include -I/tmp/buildd/ros-hydro-libuvc-camera-0.0.2-2precise-20130923-0631/include -I/opt/ros/hydro/include    -o CMakeFiles/camera_node.dir/src/main.cpp.o -c /tmp/buildd/ros-hydro-libuvc-camera-0.0.2-2precise-20130923-0631/src/main.cpp
In file included from /tmp/buildd/ros-hydro-libuvc-camera-0.0.2-2precise-20130923-0631/src/main.cpp:36:0:
/tmp/buildd/ros-hydro-libuvc-camera-0.0.2-2precise-20130923-0631/include/libuvc_camera/camera_driver.h:12:43: fatal error: libuvc_camera/UVCCameraConfig.h: No such file or directory
compilation terminated.
```
