### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/libuvc_camera/src/nodelet.cpp
+++ b/libuvc_camera/src/nodelet.cpp
@@ -74,6 +74,5 @@ void CameraNodelet::onInit() {
 
 // Register this plugin with pluginlib.
 //
-// parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(libuvc_camera, driver,
-                        libuvc_camera::CameraNodelet, nodelet::Nodelet);
+// parameters are: class type, base class type
+PLUGINLIB_EXPORT_CLASS(libuvc_camera::CameraNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions