### PR TITLE
use libuvc timestamp correctly

### DIFF
--- a/libuvc_camera/src/camera_driver.cpp
+++ b/libuvc_camera/src/camera_driver.cpp
@@ -162,7 +162,7 @@ void CameraDriver::ReconfigureCallback(UVCCameraConfig &new_config, uint32_t lev
 }
 
 void CameraDriver::ImageCallback(uvc_frame_t *frame) {
-  ros::Time timestamp = ros::Time(frame->capture_time.tv_sec, frame->capture_time.tv_usec);
+  ros::Time timestamp = ros::Time(frame->capture_time.tv_sec, frame->capture_time.tv_usec * 1000);
   if ( timestamp == ros::Time(0) ) {
     timestamp = ros::Time::now();
   }


### PR DESCRIPTION
The timestamp from libuvc contains microseconds, the ros::Time constructor wants nanoseconds.
This has not caused any issues yet because libuvc never sets the timestamp, but it will break if libuvc is ever updated to provide a timestamp.