### PR TITLE
use boost::placeholders::_1/_2 instead of deprecated _1/_2

### DIFF
--- a/libuvc_camera/CMakeLists.txt
+++ b/libuvc_camera/CMakeLists.txt
@@ -9,6 +9,11 @@ generate_dynamic_reconfigure_options(cfg/UVCCamera.cfg)
 find_package(libuvc REQUIRED)
 message(STATUS "libuvc ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH}")
 
+# this is needed to get the libuvc libraries in libuvc 0.0.7
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(libuvc REQUIRED libuvc)
+message(STATUS "libuvc libraries ${libuvc_LIBRARIES}")
+
 catkin_package(
   CATKIN_DEPENDS
     roscpp

--- a/libuvc_camera/src/camera_driver.cpp
+++ b/libuvc_camera/src/camera_driver.cpp
@@ -78,7 +78,8 @@ bool CameraDriver::Start() {
 
   state_ = kStopped;
 
-  config_server_.setCallback(boost::bind(&CameraDriver::ReconfigureCallback, this, _1, _2));
+  config_server_.setCallback(boost::bind(&CameraDriver::ReconfigureCallback, this,
+                                         boost::placeholders::_1, boost::placeholders::_2));
 
   return state_ == kRunning;
 }

--- a/libuvc_camera/src/nodelet.cpp
+++ b/libuvc_camera/src/nodelet.cpp
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include "libuvc_camera/camera_driver.h"


### PR DESCRIPTION
When building on newer systems this error results, using boost::placeholders fixes it:

```
/home/lucasw/base_catkin_ws/src/ros/libuvc_ros/libuvc_camera/src/camera_driver.cpp: In member function ‘bool libuvc_camera::CameraDriver::Start()’:
/home/lucasw/base_catkin_ws/src/ros/libuvc_ros/libuvc_camera/src/camera_driver.cpp:81:84: error: ‘_1’ was not declared in this scope
   81 |   config_server_.setCallback(boost::bind(&CameraDriver::ReconfigureCallback, this, _1, _2));
```