### PR TITLE
[ROS-O] support modern system dependencies

### DIFF
--- a/libuvc_camera/CMakeLists.txt
+++ b/libuvc_camera/CMakeLists.txt
@@ -7,7 +7,13 @@ find_package(catkin REQUIRED COMPONENTS roscpp camera_info_manager dynamic_recon
 generate_dynamic_reconfigure_options(cfg/UVCCamera.cfg)
 
 find_package(libuvc REQUIRED)
-message(STATUS "libuvc ${libuvc_VERSION_MAJOR}.${libuvc_VERSION_MINOR}.${libuvc_VERSION_PATCH}")
+# if libuvc_LIBRARIES are empty, check cmake target
+if(NOT libuvc_LIBRARIES AND TARGET LibUVC::UVCShared)
+  set(libuvc_LIBRARIES LibUVC::UVCShared)
+endif()
+if(NOT libuvc_LIBRARIES)
+  message(FATAL_ERROR "could not find expected libuvc libraries in package")
+endif()
 
 catkin_package(
   CATKIN_DEPENDS

--- a/libuvc_camera/package.xml
+++ b/libuvc_camera/package.xml
@@ -18,6 +18,7 @@
   <depend>dynamic_reconfigure</depend>
   <depend>image_transport</depend>
   <depend>libuvc-dev</depend>
+  <depend>libusb-1.0-dev</depend>
   <depend>nodelet</depend>
   <depend>sensor_msgs</depend>
 

--- a/libuvc_camera/package.xml
+++ b/libuvc_camera/package.xml
@@ -17,8 +17,7 @@
   <depend>camera_info_manager</depend>
   <depend>dynamic_reconfigure</depend>
   <depend>image_transport</depend>
-  <depend condition="$ROS_DISTRO != noetic">libuvc</depend>
-  <depend condition="$ROS_DISTRO == noetic">libuvc-dev</depend>
+  <depend>libuvc-dev</depend>
   <depend>nodelet</depend>
   <depend>sensor_msgs</depend>
 

--- a/libuvc_camera/src/camera_driver.cpp
+++ b/libuvc_camera/src/camera_driver.cpp
@@ -78,7 +78,7 @@ bool CameraDriver::Start() {
 
   state_ = kStopped;
 
-  config_server_.setCallback(boost::bind(&CameraDriver::ReconfigureCallback, this, _1, _2));
+  config_server_.setCallback([this](auto& config, auto level){ ReconfigureCallback(config, level); });
 
   return state_ == kRunning;
 }

--- a/libuvc_camera/src/nodelet.cpp
+++ b/libuvc_camera/src/nodelet.cpp
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 #include <ros/ros.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <nodelet/nodelet.h>
 
 #include "libuvc_camera/camera_driver.h"


### PR DESCRIPTION
multiple fixes to support newer versions of dependencies.

Please ask about specific changes if you find the commit messages insufficient.

Essentially  the same changes as in @lucasw 's https://github.com/ros-drivers/libuvc_ros/pull/71 (where he also added more changes since the PR was created), with a more forward-looking implementation.
